### PR TITLE
added an extra 'textannodata' JSON-LD context and tiny ontology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,15 @@ validate:
 deps:
 	@echo "Installing dependencies, you probably want to run this with sudo to install globally, but note that jsonld-cli will be installed globally from NPM rather than from a package!"
 ifeq ($(DISTRO),arch)
-	pacman -S yq npm pandoc
+	pacman -S go-yq npm pandoc
 else ifeq ($(DISTRO),$(filter $(DISTRO), debian ubuntu))
-	DEBIAN_FRONTEND=noninteractive apt-get install -y yq npm pandoc
+	@echo "Yq will be compiled from scratch"
+	DEBIAN_FRONTEND=noninteractive apt-get install -y npm pandoc golang
+	go install github.com/mikefarah/yq/v4@latest
 else ifeq ($(DISTRO),$(filter $(DISTRO), fedora redhat))
 	yum install yq npm pandoc
 else ifeq ($(DISTRO),$(filter $(DISTRO), alpine postmarketos))
-	apk add yq npm pandoc
+	apk add go-yq npm pandoc
 else ifeq ($(DISTRO),mac)
 	brew install yq npm pandoc
 endif

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ All are served under <https://ns.huc.knaw.nl> and sources are in <https://github
 
 * **text**: Ontology of concepts to mark structure in text
     * [Documentation](text.md) - [Ontology](text.json) - [JSON-LD Context](text.jsonld) 
+* **textannodata**: Context of mappings of various properties used in text & annotation, accompanied with a small ontology for properties that were created by us and could not be mapped to existing ontologies.
+    * [JSON-LD Context](textannodata.jsonld) - [Ontology](textannodata.json) -  
 * **huc-di-tt**: Old aliases for Team Text (deprecated)
     * [JSON-LD Context](huc-di-tt.jsonld)
 * **republic**: Context for the Republic project
     * [JSON-LD Context](republic.jsonld)
 * **variant Matching**: Context for variant matching, as used in the Golden Agents project
     * [JSON-LD Context](variant-matching.jsonld)
-* **globalise**: Context for the Globalise project
+* **globalise**: Context for variant matching, as used in the Golden Agents project
     * [JSON-LD Context](globalise.jsonld)
 * **skos**: Context for [SKOS](https://www.w3.org/TR/skos-reference/)
     * [JSON-LD Context](skos.jsonld)

--- a/etc/nginx/http.d/ns.conf
+++ b/etc/nginx/http.d/ns.conf
@@ -16,6 +16,9 @@ server {
         try_files /text$accept_extension =404;
 	}
 
+	location ~ /textannodata/.* {
+        try_files /textannodata$accept_extension =404;
+	}
 	# You may need this to prevent return 404 recursion.
 	location = /404.html {
 		internal;

--- a/text.json
+++ b/text.json
@@ -1,7 +1,13 @@
 {
   "@context": [
         "text.jsonld",       
-        "skos.jsonld"
+        "skos.jsonld",
+        {
+            "sameAs": {
+                "@id": "owl:sameAs",
+                "@type": "@id"
+            }
+        }
   ],
   "CommonTextVocabulary": {
         "@id": "txt:CommonTextVocabulary",

--- a/text.json
+++ b/text.json
@@ -216,7 +216,7 @@
       "definition": "Part of the document where an image/picture/graphic is located. Non-textual.",
       "inScheme": "txt:CommonTextVocabulary",
       "broader": "txt:TextStructure",
-      "sameAs": "tei:graphic"
+      "sameAs": [ "tei:graphic", "schema:ImageObject" ]
   },
   "Caption" : {
       "@id": "txt:Caption",

--- a/text.json
+++ b/text.json
@@ -6,9 +6,7 @@
   "CommonTextVocabulary": {
         "@id": "txt:CommonTextVocabulary",
         "@type": "skos:ConceptScheme",
-        "title": {
-            "en": "Common Text Vocabulary"
-        },
+        "dcterms:title": "Common Text Vocabulary",
         "hasTopConcept": "txt:TextStructure"
   },
   "TextStructure": {
@@ -295,7 +293,7 @@
       "@id": "txt:Reference",
       "@type": "skos:Concept",
       "prefLabel": "Reference",
-      "definition": "A reference to another location in the text, such as to a footnote/endnote",
+      "definition": "A reference to another location, either in the text, such as to a footnote/endnote, or an external URI. Use with schema:url.",
       "broader": "txt:TextStructure",
       "inScheme": "txt:CommonTextVocabulary",
       "sameAs": ["tei:ref", "folia:Reference"]
@@ -313,7 +311,7 @@
       "@id": "txt:Highlight",
       "@type": "skos:Concept",
       "prefLabel": "Highlight",
-      "definition": "A highlighted/emphasised piece of text, in some presentational form.",
+      "definition": "A highlighted/emphasised/stylized piece of text, in some presentational form. Use the style property to encode the form.",
       "broader": "txt:TextStructure",
       "inScheme": "txt:CommonTextVocabulary",
       "sameAs": ["tei:hi", "folia:TextMarkupStyle"]
@@ -326,13 +324,5 @@
       "inScheme": "txt:CommonTextVocabulary",
       "broader": "txt:TextStructure",
       "sameAs": ["tei:corr", "folia:Correction"]
-  },
-  "n": {
-      "@id": "txt:n",
-      "@type": "rdf:Property",
-      "prefLabel": "number",
-      "definition": "Sequence number",
-      "inScheme": "txt:CommonTextVocabulary",
-      "sameAs": ["tei:n", "folia:NAttribute"]
   }
 }

--- a/text.json
+++ b/text.json
@@ -209,11 +209,11 @@
       "broader": "txt:TextStructure",
       "sameAs": ["tei:figure", "folia:Figure" ]
   },
-  "Image" : {
-      "@id": "txt:Image",
+  "Picture" : {
+      "@id": "txt:Picture",
       "@type": "skos:Concept",
-      "prefLabel": "Image",
-      "definition": "Part of the document where an image is located. Non-textual.",
+      "prefLabel": "Picture",
+      "definition": "Part of the document where an image/picture/graphic is located. Non-textual.",
       "inScheme": "txt:CommonTextVocabulary",
       "broader": "txt:TextStructure",
       "sameAs": "tei:graphic"

--- a/text.jsonld
+++ b/text.jsonld
@@ -1,6 +1,7 @@
 {
   "@context": {
     "txt": "https://ns.huc.knaw.nl/text/",
+    "txtdata": "https://ns.huc.knaw.nl/textdata/",
     "dc": "http://purl.org/dc/elements/1.1/",
     "dcterms": "http://purl.org/dc/terms/",
     "oa": "http://www.w3.org/ns/oa#",
@@ -11,6 +12,7 @@
     "tei": "http://www.tei-c.org/ns/1.0#",
     "folia": "https://w3id.org/folia/v2/",
     "iiif": "http://iiif.io/api/presentation/3#",
+    "schema": "http://schema.org",
     "CommonTextVocabulary" : {
         "@id": "txt:CommonTextVocabulary"
     },
@@ -131,32 +133,6 @@
           "@container": "@set"
         }
       }
-    },
-    "n": {
-        "@id": "txt:n",
-        "@type": "@id"
-    },
-    "title": {
-        "@id": "dcterms:title",
-        "@container": "@language"
-    },
-    "label": {
-        "@id": "rdfs:label"
-    },
-    "comment": {
-        "@id": "rdfs:comment"
-    },
-    "description": {
-        "@id": "dcterms:description",
-        "@container": "@language"
-    },
-    "title": {
-        "@id": "dcterms:title",
-        "@container": "@language"
-    },
-    "sameAs": {
-        "@id": "owl:sameAs",
-        "@type": "@id"
     }
   }
 }

--- a/text.jsonld
+++ b/text.jsonld
@@ -85,8 +85,8 @@
     "FigureMarker" : {
         "@id": "txt:FigureMarker"
     },
-    "Image" : {
-        "@id": "txt:Image"
+    "Picture" : {
+        "@id": "txt:Picture"
     },
     "Caption" : {
         "@id": "txt:Caption"

--- a/text.md
+++ b/text.md
@@ -53,6 +53,12 @@ _URI:_ <https://ns.huc.knaw.nl/text/Figure>
 _Same as:_ <http://www.tei-c.org/ns/1.0#figure>, <https://w3id.org/folia/v2/Figure>  
 
 
+## FigureMarker
+
+_Definition:_ Figure number or marker. Should be embedded within a Figure, but not within the caption.  
+_URI:_ <https://ns.huc.knaw.nl/text/FigureMarker>
+
+
 ## Head
 
 _Definition:_ Number/marker of a section or subsection. Embedded within a section but not within a head  
@@ -62,7 +68,7 @@ _Same as:_ <http://www.tei-c.org/ns/1.0#head>, <https://w3id.org/folia/v2/head>
 
 ## Highlight
 
-_Definition:_ A highlighted/emphasised piece of text, in some presentational form.  
+_Definition:_ A highlighted/emphasised/stylized piece of text, in some presentational form. Use the style property to encode the form.  
 _URI:_ <https://ns.huc.knaw.nl/text/Highlight>
 _Same as:_ <http://www.tei-c.org/ns/1.0#hi>, <https://w3id.org/folia/v2/TextMarkupStyle>  
 
@@ -162,7 +168,7 @@ _Same as:_ <http://www.tei-c.org/ns/1.0#q>, <https://w3id.org/folia/v2/Quote>
 
 ## Reference
 
-_Definition:_ A reference to another location in the text, such as to a footnote/endnote  
+_Definition:_ A reference to another location, either in the text, such as to a footnote/endnote, or an external URI. Use with schema:url.  
 _URI:_ <https://ns.huc.knaw.nl/text/Reference>
 _Same as:_ <http://www.tei-c.org/ns/1.0#ref>, <https://w3id.org/folia/v2/Reference>  
 

--- a/text_intro.md
+++ b/text_intro.md
@@ -10,7 +10,7 @@ The aims are:
 1. to ensure all vocabulary we use is properly documented and formalised
 2. to unify vocabularies as much as possible so we don't have different concepts for the same things in different places.
 3. to employ a consistent vocabulary in various projects and amongst various software components
-4. to make clear to which tools in our pipeline rely on what vocabulary to function.
+4. to make clear which tools in our pipeline rely on what vocabulary to function.
 5. to adhere to and reuse established standards (like the W3C Web Annotation Data Model) as much as possible and minimise the addition of new vocabulary 
 
 You can read more about our service-oriented architecture

--- a/text_intro.md
+++ b/text_intro.md
@@ -58,11 +58,19 @@ service infrastructure.
 
 Formats like TEI, FoLiA and PageXML themselves define a vocabulary pertaining to textual structure and annotations.
 As our data comes from a variety of sources, we use a common basic vocabulary
-that is distinct but largely derived from the above. The vocabulary is formalised and documented in:
+that is distinct but largely derived from the above. The vocabulary is formalised and documented in two different modules:
 
-* Ontology: [text.json](text.json) with [documentation](text.md)
-* JSON-LD context: [text.jsonld](text.jsonld) 
-    * This will be served at  <https://ns.huc.knaw.nl/text.jsonld>.
+1. Text structure (SKOS)
+    * Ontology: [text.json](text.json) with [documentation](text.md)
+    * JSON-LD context: [text.jsonld](text.jsonld) 
+        * This will be served at  <https://ns.huc.knaw.nl/text.jsonld>.
+2. Properties for Text & Annotations
+    * Ontology: [textannodata.json](textannodata.json)
+        * This ontology is kept as small as possible, and contains only those properties
+          for which we found no suitable mapping in an existing ontology.
+    * JSON-LD context: [textannodata.jsonld](textannodata.jsonld) (documentation: see *Mapping properties* section)
+        * We prefer to map properties to existing properties in other ontologies (such as schema.org)
+        * This will be served at  <https://ns.huc.knaw.nl/textannodata.jsonld>.
 
 ### Anatomy of a Web Annotation
 
@@ -73,6 +81,7 @@ The following example shows an example web annotation:
   "@context": [
     "http://www.w3.org/ns/anno.jsonld",
     "https://ns.huc.knaw.nl/text.jsonld",
+    "https://ns.huc.knaw.nl/textannodata.jsonld",
   ],
   "type": "Annotation",
   "id": "https://preview.dev.diginfra.org/annorepo/w3c/israels/9a9422f7-f796-4c4a-afe8-f94579f36c81",
@@ -81,17 +90,28 @@ The following example shows an example web annotation:
   "body": {
     "id": "urn:someproject:letter:001",
     "type": "Letter",
-    "TODO:manifest": "https://preview.dev.diginfra.org/files/israels/static/manifests/letters/ii001.json",
-    "TODO:correspondent": "Jo van Gogh-Bonger",
-    "TODO:file": "ii001",
-    "TODO:institution": "VGM",
-    "TODO:location": "Amsterdam, The Netherlands",
+    "manifest": "https://preview.dev.diginfra.org/files/israels/static/manifests/letters/ii001.json",
+    "recipient": {
+            "type": "Person",
+            "name": "Jo van Gogh-Bonger",
+    },
+    "identifier": "ii001",
+    "provider": {
+            "type": "Organization",
+            "name": "Van Gogh Museum",
+    }
+    "location": {
+            "type": "Place",
+            "name": "Amsterdam, The Netherlands",
+    }
     "TODO:msId": "b8564V2008",
-    "TODO:period": "1891-02-02",
-    "TODO:periodLong": "",
-    "TODO:sender": "Isaac Israëls",
-    "TODO:nextLetter": "urn:israels:letter:ii002",
-    "title": {
+    "datePublished": "1891-02-02",
+    "sender": {
+            "type": "Person",
+            "name": "Isaac Israëls",
+    },
+    "next": "urn:israels:letter:ii002",
+    "titles": {
       "nl": "Isaac Israëls aan Jo van Gogh-Bonger. Amsterdam, 2 februari 1891.",
       "en": "Isaac Israëls to Jo van Gogh-Bonger. Amsterdam, 2 February 1891."
     }        
@@ -183,3 +203,95 @@ The following example shows an example web annotation:
 ```
 
 **Note**: Parts with prefix *TODO:* are still be reconciled with into the new vocabulary.
+
+### Mapping properties
+
+We try to map properties for text and annotation, as extracted from the various sources (e.g. TEI, PageXML), to existing linked open data ontologies. Only if no suitable property can be found, do we create one of our own in [textannodata.json](textannodata.json).
+
+The following custom target properties are defined in the [textannodata.json](textannodata.json) ontology:
+
+**Note:** The links in these table are URIs in the RDF sense. Whilst it is good practise that they are resolvable as URLs, they may not be necessarily so.
+
+| Alias | Property | Description        |
+| ----- | -------- | ------------------ |
+| n | <https://ns.huc.knaw.nl/textannodata/n> |  Sequence number |
+| style | <https://ns.huc.knaw.nl/textannodata/style> |  Encodes the rendition style of a piece of text. The vocabulary is open-ended and may contain terms as 'italic', 'bold','underlined', common color names (red,blue,green) or `#rrggbb` color codes. This property is expected on Highlight annotations. |
+
+The following properties from existing ontologies are defined in the [textannodata.jsonld](textannodata.jsonld) JSON-LD context:
+
+| Alias | Property | Description        |
+| ----- | -------- | ------------------ |
+| address | <http://schema.org/address> |  Physical address of the item |
+| dateCreated | <http://schema.org/dateCreated> |  Date of creation |
+| dateModified | <http://schema.org/dateModified> |  Date of modification |
+| datePublished | <http://schema.org/datePublished> |  Date of first publication |
+| description | <http://purl.org/dc/terms/description> | Description of something |
+| descriptions | <http://purl.org/dc/terms/description> | Description of something (in `@language` container) |
+| editor | <http://schema.org/editor> |  Specifies the Person who edited the CreativeWork. |
+| genre | <http://schema.org/genre> | Genre of the creative work (text or URL) |
+| identifier | <http://purl.org/dc/terms/identifier> | An unambiguous reference to the resource within a given context. Recommended practice is to identify the resource by means of a string conforming to an identification system. Examples include International Standard Book Number (ISBN), Digital Object Identifier (DOI), and Uniform Resource Name (URN). Persistent identifiers should be provided as HTTP URIs. |
+| image | <http://schema.org/image> | An image of the item |
+| keywords | <http://schema.org/keywords> | Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property. | 
+| knows | <http://schema.org/knows> | The most generic bi-directional social/work relation. Used with schema:Person (domain + range). |
+| license | <http://schema.org/license> | A license document that applies to this content, typically indicated by URL |
+| location | <http://schema.org/location> | Location of something (e.g. where the resource was published), text or URL or Place |
+| manifest | <http://iiif.io/api/presentation/3#hasManifests> | Link to IIIF manifest (may be list of multiple) |
+| participant | <http://schema.org/participants> | Other co-agents that participated in the action indirectly. |
+| producer | <http://schema.org/producer> | The person or organization who produced the work. Expects a non-literal. |
+| provider | <http://schema.org/provider> | The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Expects a non-literal (Organization or Person) |
+| publisher | <http://purl.org/dc/terms/publisher> | An entity responsible for making the resource available. Expects a non-literal (Organization or Person) |
+| recipient | <http://schema.org/recipient> | The participant who is at the receiving end of the action. Expects a non-literal (Organization or Person) |
+| references | <http://purl.org/dc/terms/references> | A related resource that is referenced, cited, or otherwise pointed to by the described resource. This property is intended to be used with non-literal values. |
+| relation | <http://purl.org/dc/terms/relation> | A related resource. Recommended practice is to identify the related resource by means of a URI. If this is not possible or feasible, a string conforming to a formal identification system may be provided. |
+| replaces | <http://purl.org/dc/terms/replaces> |  A related resource that is supplanted, displaced, or superseded by the described resource. this property is intended to be used with non-literal values. |
+| sender | <http://schema.org/sender> | The participant who is at the sending end of the action. |
+| sourceUrl | <http://purl.org/dc/terms/source> | URL to where a resource was sourced from |
+| subject | <http://purl.org/dc/terms/subject> | A topic of the resource. Recommended practice is to refer to the subject with a URI. If this is not possible or feasible, a literal value that identifies the subject may be provided. Both should preferably refer to a subject in a controlled vocabulary. |
+| title | <http://purl.org/dc/terms/title> | Title |
+| titles | <http://purl.org/dc/terms/title> | Title (in `@language` container) |
+
+The following (non-exhaustive!) properties come from the [W3C Web Annotation (anno.jsonld)](anno.jsonld) JSON-LD context:
+
+| Alias | Property | Description        |
+| ----- | -------- | ------------------ |
+| audience | <http://schema.org/audience> | An intended audience, i.e. a group for whom something was created. |
+| created | <http://purl.org/dc/terms/created> | Date of creation |
+| creator | <http://purl.org/dc/terms/creator> | An entity primarily responsible for making the resource. Typically, the name of a Creator should be used to indicate the entity. |
+| conformsTo | <http://purl.org/dc/terms/conformsTo>  | An established standard to which the described resource conforms. |
+| email  | <http://xmlns.com/foaf/0.1/email> | E-mail address |
+| format | <http://purl.org/dc/elements/1.1/format> | The file format, physical medium, or dimensions of the resource. | 
+| generator | <http://www.w3.org/ns/activitystreams#generator> | Identifies the entity (e.g. an application) that generated the object.  |
+| generated | <http://purl.org/dc/terms/issued> | Date of generation/publication/generation |
+| language | <http://purl.org/dc/elements/1.1/language> | A language of the resource.  Recommended practice is to use either a non-literal value representing a language from a controlled vocabulary such as ISO 639-2 or ISO 639-3, or a literal value consisting of an IETF Best Current Practice 47 [IETF-BCP47] language tag. |
+| label | <http://www.w3.org/2000/01/rdf-schema#label> | Ties a human-readable label to something |
+| modified | <http://purl.org/dc/terms/modified> | Date of modification |
+| next | <http://www.w3.org/ns/activitystreams#next> | Used to link one item to the next one (of the same type) in a sequence |
+| partOf | <http://www.w3.org/ns/activitystreams#partOf> | marks something as a part of something bigger |
+| prev | <http://www.w3.org/ns/activitystreams#prev> | Used to link one item to the previous one (of the same type) in a sequence |
+| rights | <http://purl.org/dc/elements/1.1/rights> | Information about rights held in and over the resource. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided. | 
+
+The following aliases from the [W3C Web Annotation (anno.jsonld)](anno.jsonld) JSON-LD context are [overridden](https://www.w3.org/TR/json-ld/#advanced-context-usage) by definitions in [textannodata.jsonld](textannodata.jsonld):
+
+| Alias | W3C Web Annotation | Overriden        |
+| ----- | -------- | ------------------ |
+| Person | <http://xmlns.com/foaf/0.1/Person> | <http://schema.org/Person> |
+| Organization | <http://xmlns.com/foaf/0.1/Organization> | <http://schema.org/Organization> |
+| name | <http://xmlns.com/foaf/0.1/name>  | <http://schema.org/name> | 
+
+The following table maps some (non-exhaustive) [old-style properties (not further formalised)](https://github.com/knaw-huc/team-text-backlog/issues/128) to the new ones:
+
+| Old | New     |
+| ----- | -------- |
+| institution | provider |
+| eid/entityId | identifier |
+| fileId/letterId/pageId | identifier |
+| idno | identifier |
+| headerId | identifier |
+| nextLetter/nextFile/nextPage | next |
+| prevLetter/prevFile/prevPage | prev |
+| correspondent | recipient (structured!) |
+| sender | sender (structured!) |
+| pageUrl | url |
+| displayLabel | label |
+| rend | style |
+

--- a/text_intro.md
+++ b/text_intro.md
@@ -258,7 +258,7 @@ The following (non-exhaustive!) properties come from the [W3C Web Annotation (an
 | created | <http://purl.org/dc/terms/created> | Date of creation |
 | creator | <http://purl.org/dc/terms/creator> | An entity primarily responsible for making the resource. Typically, the name of a Creator should be used to indicate the entity. |
 | conformsTo | <http://purl.org/dc/terms/conformsTo>  | An established standard to which the described resource conforms. |
-| email  | <http://xmlns.com/foaf/0.1/email> | E-mail address |
+| email  | <http://xmlns.com/foaf/0.1/mbox> | E-mail address |
 | format | <http://purl.org/dc/elements/1.1/format> | The file format, physical medium, or dimensions of the resource. | 
 | generator | <http://www.w3.org/ns/activitystreams#generator> | Identifies the entity (e.g. an application) that generated the object.  |
 | generated | <http://purl.org/dc/terms/issued> | Date of generation/publication/generation |
@@ -269,14 +269,6 @@ The following (non-exhaustive!) properties come from the [W3C Web Annotation (an
 | partOf | <http://www.w3.org/ns/activitystreams#partOf> | marks something as a part of something bigger |
 | prev | <http://www.w3.org/ns/activitystreams#prev> | Used to link one item to the previous one (of the same type) in a sequence |
 | rights | <http://purl.org/dc/elements/1.1/rights> | Information about rights held in and over the resource. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided. | 
-
-The following aliases from the [W3C Web Annotation (anno.jsonld)](anno.jsonld) JSON-LD context are [overridden](https://www.w3.org/TR/json-ld/#advanced-context-usage) by definitions in [textannodata.jsonld](textannodata.jsonld):
-
-| Alias | W3C Web Annotation | Overriden        |
-| ----- | -------- | ------------------ |
-| Person | <http://xmlns.com/foaf/0.1/Person> | <http://schema.org/Person> |
-| Organization | <http://xmlns.com/foaf/0.1/Organization> | <http://schema.org/Organization> |
-| name | <http://xmlns.com/foaf/0.1/name>  | <http://schema.org/name> | 
 
 The following table maps some (non-exhaustive) [old-style properties (not further formalised)](https://github.com/knaw-huc/team-text-backlog/issues/128) to the new ones:
 

--- a/textannodata.json
+++ b/textannodata.json
@@ -1,0 +1,18 @@
+{
+  "@context": [
+        "textannodata.jsonld"
+  ],
+  "n": {
+      "@id": "txt:n",
+      "@type": "rdf:Property",
+      "label": "number",
+      "description": "Sequence number",
+      "sameAs": ["tei:n", "folia:NAttribute"]
+  },
+  "style": {
+      "@id": "txt:style",
+      "@type": "rdf:Property",
+      "label": "style",
+      "description": "Encodes the rendition style of a piece of text. The vocabulary is open-ended and may contain terms as 'italic', 'bold','underlined', common color names (red,blue,green) or #rrggbb color codes. This property is expected on Highlight annotations."
+  }
+}

--- a/textannodata.jsonld
+++ b/textannodata.jsonld
@@ -18,14 +18,8 @@
     "style": {
         "@id": "tad:style"
     },
-    "name": {
-        "@id": "schema:name"
-    },
     "url": {
         "@id": "schema:url"
-    },
-    "email": {
-        "@id": "schema:email"
     },
     "identifier": {
         "@id": "dcterms:identifier"
@@ -126,22 +120,26 @@
         "@type": "@id"
     },
     "image": "schema:image",
-    "Person": {
+    "SchemaPerson": {
         "@id": "schema:Person",
         "@context": {
+            "name": "schema:name",
             "description": "schema:description",
             "identifier": "schema:identifier",
+            "email": "schema:email",
             "sameAs": {
                 "@id": "schema:sameAs",
                 "@type": "@id"
             }
         }
     },
-    "Organization": {
+    "SchemaOrganization": {
         "@id": "schema:Organization",
         "@context": {
+            "name": "schema:name",
             "description": "schema:description",
             "identifier": "schema:identifier",
+            "email": "schema:email",
             "sameAs": {
                 "@id": "schema:sameAs",
                 "@type": "@id"

--- a/textannodata.jsonld
+++ b/textannodata.jsonld
@@ -190,6 +190,20 @@
             }
         }
     },
-    "address": "schema:address"
+    "address": "schema:address",
+    "ImageObject": {
+        "@id": "schema:ImageObject",
+        "@context": {
+            "name": "schema:name",
+            "description": "schema:description",
+            "identifier": "schema:identifier",
+            "width": "schema:width",
+            "height": "schema:height",
+            "sameAs": {
+                "@id": "schema:sameAs",
+                "@type": "@id"
+            }
+        }
+    }
   }
 }

--- a/textannodata.jsonld
+++ b/textannodata.jsonld
@@ -1,0 +1,196 @@
+{
+  "@context": {
+    "tad": "https://ns.huc.knaw.nl/textannodata/",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "oa": "http://www.w3.org/ns/oa#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "pagexml": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15/",
+    "tei": "http://www.tei-c.org/ns/1.0#",
+    "folia": "https://w3id.org/folia/v2/",
+    "iiif": "http://iiif.io/api/presentation/3#",
+    "schema": "http://schema.org",
+    "n": {
+        "@id": "tad:n"
+    },
+    "style": {
+        "@id": "tad:style"
+    },
+    "name": {
+        "@id": "schema:name"
+    },
+    "url": {
+        "@id": "schema:url"
+    },
+    "email": {
+        "@id": "schema:email"
+    },
+    "identifier": {
+        "@id": "dcterms:identifier"
+    },
+    "title": {
+        "@id": "dcterms:title"
+    },
+    "titles": {
+        "@id": "dcterms:title",
+        "@container": "@language"
+    },
+    "label": {
+        "@id": "rdfs:label"
+    },
+    "labels": {
+        "@id": "rdfs:label",
+        "@container": "@language"
+    },
+    "description": {
+        "@id": "dcterms:description"
+    },
+    "descriptions": {
+        "@id": "dcterms:description",
+        "@container": "@language"
+    },
+    "sourceUrl": {
+        "@id": "dcterms:source"
+    },
+    "editor": {
+        "@id": "schema:editor"
+    },
+    "genre": {
+        "@id": "schema:genre"
+    },
+    "license": {
+        "@id": "schema:license"
+    },
+    "datePublished": {
+        "@id": "schema:datePublished"
+    },
+    "dateCreated": {
+        "@id": "schema:dateCreated"
+    },
+    "dateModified": {
+        "@id": "schema:dateModified"
+    },
+    "keywords": {
+        "@id": "schema:keywords"
+    },
+    "relation": {
+        "@id": "dcterms:relation"
+    },
+    "references": {
+        "@id": "dcterms:references",
+        "@type": "@id"
+    },
+    "publisher": {
+        "@id": "dcterms:publisher"
+    },
+    "replaces": {
+        "@id": "dcterms:replaces",
+        "@type": "@id"
+    },
+    "manifest": {
+        "@id": "iiif:hasManifests",
+        "@container": "@list"
+    },
+    "recipient": {
+        "@id": "schema:recipient",
+        "@type": "@id"
+    },
+    "participant": {
+        "@id": "schema:participant",
+        "@type": "@id"
+    },
+    "sender": {
+        "@id": "schema:sender",
+        "@type": "@id"
+    },
+    "sameAs": {
+        "@id": "owl:sameAs",
+        "@type": "@id"
+    },
+    "affiliation": {
+        "@id": "schema:affiliation", 
+        "@type": "@id"
+    },
+    "author": {
+        "@id": "schema:author",
+        "@type": "@id"
+    },
+    "producer": {
+        "@id": "schema:producer",
+        "@type": "@id"
+    },
+    "provider": {
+        "@id": "schema:producer",
+        "@type": "@id"
+    },
+    "image": "schema:image",
+    "Person": {
+        "@id": "schema:Person",
+        "@context": {
+            "description": "schema:description",
+            "identifier": "schema:identifier",
+            "sameAs": {
+                "@id": "schema:sameAs",
+                "@type": "@id"
+            }
+        }
+    },
+    "Organization": {
+        "@id": "schema:Organization",
+        "@context": {
+            "description": "schema:description",
+            "identifier": "schema:identifier",
+            "sameAs": {
+                "@id": "schema:sameAs",
+                "@type": "@id"
+            }
+        }
+    },
+    "birthDate": "schema:birthDate",
+    "birthPlace": "schema:birthPlace",
+    "deathDate": "schema:deathDate",
+    "deathPlace": "schema:deathPlace",
+    "honorificPrefix": "schema:honorificPrefix",
+    "honorificSuffix": "schema:honorificSuffix",
+    "knows": { 
+        "@id": "schema:knows",
+        "@type": "@id"
+    },
+    "gender": "schema:gender",
+    "occupation": "schema:hasOccupation",
+    "Occupation": {
+        "@id": "schema:Occupation",
+        "@context": {
+            "description": "schema:description",
+            "identifier": "schema:identifier",
+            "sameAs": {
+                "@id": "schema:sameAs",
+                "@type": "@id"
+            }
+        }
+    },
+    "location": {
+        "@id": "schema:location"
+    },
+    "fromLocation": {
+        "@id": "schema:fromLocation"
+    },
+    "toLocation": {
+        "@id": "schema:toLocation"
+    },
+    "Place": {
+        "@id": "schema:Place",
+        "@context": {
+            "name": "schema:name",
+            "description": "schema:description",
+            "identifier": "schema:identifier",
+            "sameAs": {
+                "@id": "schema:sameAs",
+                "@type": "@id"
+            }
+        }
+    },
+    "address": "schema:address"
+}

--- a/textannodata.jsonld
+++ b/textannodata.jsonld
@@ -191,4 +191,5 @@
         }
     },
     "address": "schema:address"
+  }
 }


### PR DESCRIPTION
This context defines aliases that map various properties to DMCI, schema.org and some others. These are to be used in the bodies of annotations. The aliases are documented in `text_intro.md`.

Terms from TEI, PageXML and other sources will have to be explicitly mapped to a fitting category. This effort is by no means complete yet, but this is an indication of the direction I'd like to go in.

Highly project-specific properties are not included here, these will land in separate context definitions/ontologies.